### PR TITLE
chore: delete low-p-bug type from Git2GUS config file

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -2,7 +2,6 @@
   "productTag": "a1aB0000000YP4JIAW",
   "issueTypeLabels": {
     "type:bug": "BUG P3",
-    "type:low-p-bug": "BUG P4",
     "type:enhancement": "USER STORY"
   },
   "hideWorkItemUrl": "true",


### PR DESCRIPTION
Delete the unused label: `type:low-p-bug` from git2gus config file